### PR TITLE
Add '\n' at begin and end of code input

### DIFF
--- a/src/eval/execute.rs
+++ b/src/eval/execute.rs
@@ -83,7 +83,7 @@ fn generate_code_to_send(code: &str, bare: bool) -> String {
     let (header, body) = extract_code_headers(code);
     debug!("extract: {:?} -> ({:?}, {:?})", code, header, body);
     let code = if body.contains("println!") || body.contains("print!") {
-        format!("{{{code}}};")
+        format!("{{\n{code}\n}};")
     } else {
         format!(
             template! {


### PR DESCRIPTION
or the '}' in the wrapper code might be commented by user input